### PR TITLE
Update swift version 3.0 => 4.0 to make usable

### DIFF
--- a/lib/fastlane/plugin/ionic_integration/actions/ionic_ios_snapshot_action.rb
+++ b/lib/fastlane/plugin/ionic_integration/actions/ionic_ios_snapshot_action.rb
@@ -144,7 +144,7 @@ module Fastlane
         end
 
         target.build_configuration_list.set_setting('INFOPLIST_FILE', File.absolute_path("#{config_folder}/Info.plist"))
-        target.build_configuration_list.set_setting('SWIFT_VERSION', '3.0')
+        target.build_configuration_list.set_setting('SWIFT_VERSION', '4.0')
         target.build_configuration_list.set_setting('PRODUCT_NAME', "$(TARGET_NAME)")
         target.build_configuration_list.set_setting('TEST_TARGET_NAME', project_name)
         target.build_configuration_list.set_setting('PRODUCT_BUNDLE_IDENTIFIER', "#{bundle_id}.#{scheme_name}")


### PR DESCRIPTION
I have been using this plugin for a while and recently noticed some breaking changes in Xcode min required version for swift. I've updated and it seems to run without a hitch.